### PR TITLE
Heap integration

### DIFF
--- a/book/netlify/build.sh
+++ b/book/netlify/build.sh
@@ -8,3 +8,6 @@ make update
 
 # build documentation
 make ci
+
+# inject Heap analytics snippet into the generated HTML
+python3 scripts/inject_heap.py

--- a/book/preview-trigger.txt
+++ b/book/preview-trigger.txt
@@ -1,0 +1,1 @@
+Preview trigger file to force Netlify deploy preview. No functional site changes.

--- a/preview-trigger.txt
+++ b/preview-trigger.txt
@@ -1,0 +1,1 @@
+Preview trigger file to create a diff for Netlify deploy previews. No functional site changes.

--- a/scripts/inject_heap.py
+++ b/scripts/inject_heap.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Insert the Heap base snippet into every built HTML page.
+Run this after the static site build so Heap is present on all pages.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+HEAP_APP_ID = os.environ.get("HEAP_APP_ID") or "902525459"
+OUTPUT_ROOTS = [Path("book/_build/html"), Path("book/_build/site/public")]
+
+SNIPPET = """<!-- Heap Analytics -->
+<script>
+  window.heap = window.heap || [];
+  heap.load = function (appid, config) {
+    window.heap.appid = appid;
+    window.heap.config = config = config || {};
+    var script = document.createElement("script");
+    script.type = "text/javascript";
+    script.async = true;
+    script.src = "https://cdn.heapanalytics.com/js/heap-" + appid + ".js";
+    var firstScript = document.getElementsByTagName("script")[0];
+    firstScript.parentNode.insertBefore(script, firstScript);
+    var methods = [
+      "addEventProperties",
+      "addUserProperties",
+      "clearEventProperties",
+      "identify",
+      "resetIdentity",
+      "removeEventProperty",
+      "setEventProperties",
+      "track",
+      "unsetEventProperty"
+    ];
+    function factory(method) {
+      return function () {
+        heap.push([method].concat(Array.prototype.slice.call(arguments, 0)));
+      };
+    }
+    for (var i = 0; i < methods.length; i++) {
+      heap[methods[i]] = factory(methods[i]);
+    }
+  };
+  heap.load("%s");
+</script>"""
+
+
+def inject(html_path: Path, snippet: str, marker: str) -> bool:
+    text = html_path.read_text(encoding="utf-8")
+
+    # Skip if any Heap snippet/config is already present
+    existing_markers = (
+        marker,
+        "cdn.heapanalytics.com/js/heap-",
+        "cdn.us.heap-api.com/config",
+        "window.heapReadyCb",
+    )
+    if any(m in text for m in existing_markers):
+        return False
+
+    if "</head>" not in text:
+        return False
+
+    updated = text.replace("</head>", f"{snippet}\n</head>", 1)
+    html_path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def main() -> int:
+    snippet = SNIPPET % HEAP_APP_ID
+    marker = f"heap-{HEAP_APP_ID}.js"
+    roots_found = False
+    modified = 0
+
+    for root in OUTPUT_ROOTS:
+        if not root.exists():
+            continue
+        roots_found = True
+        for html_file in root.rglob("*.html"):
+            if inject(html_file, snippet, marker):
+                modified += 1
+
+    if not roots_found:
+        print("No built HTML directories found.", file=sys.stderr)
+        return 1
+
+    print(f"Injected Heap snippet into {modified} file(s) using HEAP_APP_ID={HEAP_APP_ID}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/inject_heap.py
+++ b/scripts/inject_heap.py
@@ -11,10 +11,10 @@ import sys
 from pathlib import Path
 
 
-HEAP_APP_ID = os.environ.get("HEAP_APP_ID") or "902525459"
+HEAP_APP_ID = os.environ.get("HEAP_APP_ID") or "902525459" # TODO: remove after testing
 OUTPUT_ROOTS = [Path("book/_build/html"), Path("book/_build/site/public")]
 
-SNIPPET = """<!-- Heap Analytics -->
+SNIPPET = """
 <script>
   window.heap = window.heap || [];
   heap.load = function (appid, config) {

--- a/scripts/serve_with_fallback.py
+++ b/scripts/serve_with_fallback.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+Dev server for the built site with clean-URL fallback.
+
+Behavior:
+- Serves from book/_build/html
+- If the requested path is missing, tries "<path>.html"
+- If still missing, falls back to "index.html" (SPA-style)
+
+Usage:
+    PORT=3001 python3 scripts/serve_with_fallback.py
+"""
+
+from __future__ import annotations
+
+import http.server
+import os
+from pathlib import Path
+from urllib.parse import unquote
+
+
+ROOT = Path(__file__).resolve().parent.parent / "book" / "_build" / "html"
+
+
+class FallbackHandler(http.server.SimpleHTTPRequestHandler):
+    def translate_path(self, path: str) -> str:
+        path = unquote(path.split("?", 1)[0].split("#", 1)[0])
+        return str(ROOT / path.lstrip("/"))
+
+    def send_head(self):
+        path = Path(self.translate_path(self.path))
+
+        # Existing file/dir
+        if path.is_dir():
+            index = path / "index.html"
+            if index.exists():
+                path = index
+            else:
+                return super().send_head()
+        elif not path.exists():
+            html_path = Path(f"{path}.html")
+            if html_path.exists():
+                path = html_path
+            else:
+                path = ROOT / "index.html"
+
+        ctype = self.guess_type(str(path))
+        try:
+            f = open(path, "rb")
+        except OSError:
+            return self.send_error(404, "File not found")
+
+        self.send_response(200)
+        self.send_header("Content-type", ctype)
+        fs = os.fstat(f.fileno())
+        self.send_header("Content-Length", str(fs[6]))
+        self.send_header("Last-Modified", self.date_time_string(fs.st_mtime))
+        self.end_headers()
+        return f
+
+    def log_message(self, format, *args):
+        pass  # quiet
+
+
+def run(port: int = 3001):
+    os.chdir(ROOT)
+    http.server.test(HandlerClass=FallbackHandler, port=port)
+
+
+if __name__ == "__main__":
+    port_env = os.environ.get("PORT")
+    try:
+        port = int(port_env) if port_env else 3001
+    except ValueError:
+        port = 3001
+    run(port)


### PR DESCRIPTION
  **What this PR does**

  - Adds Heap to all built pages without altering content/UI.
  - Post-build injector: book/netlify/build.sh runs python3 scripts/inject_heap.py after make ci so the Heap snippet is inserted into book/_build/html (and book/_build/site/public if present).
  - Local dev helper: scripts/serve_with_fallback.py serves the static build with clean-URL fallback (optional; does not affect prod).

  **Heap details**

  - Env ID: 902525459 (override via HEAP_APP_ID if needed).
  - Injector logic (scripts/inject_heap.py):
      - Walks built HTML; inserts the standard Heap snippet before </head>.
      - Skips if any Heap snippet/config is already present to avoid double-load.
  - Expected requests when tracking works:
      - Loader: https://cdn.heapanalytics.com/js/heap-902525459.js
      - Event beacons: https://heapanalytics.com/h?...(200/204)

  **How to verify**

  1. Build and inject:

     conda run -n cuahsi-open-learning-env make ci
     python3 scripts/inject_heap.py
  2. Serve static with fallback (optional):

     PORT=3001 python3 scripts/serve_with_fallback.py
  3. Check in browser:
      - View Source: Heap block in <head>.
      - Network: loader + /h beacons.
      - Console: window.heap defined