### PR TITLE
Create a CUAHSI Research Notebooks section; Issue #71

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -60,6 +60,6 @@
 	path = book/courseware/hydroinformatics/Front_Matter
 	url = https://github.com/abnerbog/Front_Matter
 [submodule "book/code-labs/notebooks"]
-	path = book/code-labs/notebooks
+	path = book/code-labs/cuahsi-research-notebooks/notebooks
 	url = https://github.com/CUAHSI/notebooks
 	branch = develop

--- a/book/code-labs/code-labs.md
+++ b/book/code-labs/code-labs.md
@@ -18,6 +18,6 @@ The "Workbench" for applied technical skills and reproducible science.
 
 </div>
 
-## Available Resources
+## Available Collections
 
-- [Collecting and Manipulating AORC Meteorological Data](<notebooks/Data Access Examples/AORC - Data Collection and Manipulation Primer/collecting-and-manipulating-aorc-v1.1-myst>): A Jupyter notebook showing how to work with the NOAA Analysis of Record for Calibration (AORC) meteorological dataset from the cloud in Python, including subsetting, visualization, and linking gridded data to watershed boundaries.
+- [CUAHSI Research Notebook collection](<cuahsi-research-notebooks>): A collection of CUAHSI research Jupyter notebooks used for workshops. 

--- a/book/code-labs/cuahsi-research-notebooks/cuahsi-research-notebooks.md
+++ b/book/code-labs/cuahsi-research-notebooks/cuahsi-research-notebooks.md
@@ -1,0 +1,21 @@
+---
+title: CUAHSI Research Notebooks
+authors:
+  id: cuahsi
+date: 2026-04-22
+---
+
+[🏠 Back to Home](/)
+
+<div style="background: linear-gradient(135deg, #e1f5fe 0%, #b3e5fc 100%); padding: 1rem 1.5rem; color: #003366; margin-bottom: 2rem; border-radius: 8px; border: 1px solid #b3e5fc;">
+
+<h3 style="margin-top: 0; color: #003366;">Overview</h3>
+
+- **Format:** Jupyter notebooks
+- **Goal:** Applied technical skills and reproducible science
+
+</div>
+
+## Available Resources
+
+- [Collecting and Manipulating AORC Meteorological Data](<notebooks/Data Access Examples/AORC - Data Collection and Manipulation Primer/collecting-and-manipulating-aorc-v1.1-myst>): A Jupyter notebook showing how to work with the NOAA Analysis of Record for Calibration (AORC) meteorological dataset from the cloud in Python, including subsetting, visualization, and linking gridded data to watershed boundaries.

--- a/book/code-labs/cuahsi-research-notebooks/cuahsi-research-notebooks.md
+++ b/book/code-labs/cuahsi-research-notebooks/cuahsi-research-notebooks.md
@@ -3,24 +3,23 @@ title: CUAHSI Research Notebooks
 subtitle: A free, open source gallery of hydrologic and data science Jupyter Notebooks compiled by the CUAHSI community.
 date: 2026-04-22
 github: https://github.com/CUAHSI/notebooks
-authors:
-  - id: cuahsi
-    name: The CUAHSI Community
-    affiliations:
-    - id: cuahsi-affiliation
-      name: CUAHSI - Consortium of Universities for the Advancement of Hydrologic Science, Inc.
-      url: https://cuahsi.org/
-toc: true
+subject: Code Labs
+doi: https://doi.org/10.4211/hs.9922f9d181b64c9592b36293fe586491
+venue:
+  title: View Resource on HydroShare
+  url: https://hydroshare.org/resource/9922f9d181b64c9592b36293fe586491/
 ---
-
-[🏠 Back to Home](/)
 
 # Introduction  
 
-**The CUAHSI Research Notebooks gallary a community-curated collection of Jupyter Notebooks that demonstrate practical workflows for hydrologic data access, analysis, and modeling. It showcases reproducible, executable examples that combine code, data, and narrative to support research and education in water science. These notebooks are designed to be used independently, allowing users to learn specific tools or methods without needing to follow a fixed sequence.**  
+The CUAHSI Research Notebooks gallery is a community-curated collection of Jupyter Notebooks that demonstrate practical workflows for hydrologic data access, analysis, and modeling. It showcases reproducible, executable examples that combine code, data, and narrative to support research and education in water science. These notebooks cover a range of topics, from retrieving and processing observational and model datasets to running hydrologic simulations and comparing gridded climate products. They are contributed by members of the CUAHSI community and reflect real workflows used in water science research. All notebooks are available in the [Notebooks Repository on the CUAHSI GitHub](https://github.com/CUAHSI/notebooks).
 
-These notebooks are available in the [Notebooks Repository on the CUAHSI GitHub](https://github.com/CUAHSI/notebooks).
 
-# Available Notebooks
+# How to use these materials
+
+These notebooks are designed to be used independently, allowing users to learn specific tools or methods without needing to follow a fixed sequence. Each notebook includes the code, data, and explanations needed to work through the example on its own. Most notebooks can be run in a cloud environment without any local software installation, though instructions for setting up a local environment are provided where relevant. Users new to Python or Jupyter Notebooks may want to start with the data access examples before moving on to the science examples, which tend to assume more familiarity with hydrologic datasets and analysis workflows.
+
+
+# Table of contents
 
 - [Collecting and Manipulating AORC Meteorological Data](<notebooks/Data Access Examples/AORC - Data Collection and Manipulation Primer/collecting-and-manipulating-aorc-v1.1-myst>): A Jupyter notebook showing how to work with the NOAA Analysis of Record for Calibration (AORC) meteorological dataset from the cloud in Python, including subsetting, visualization, and linking gridded data to watershed boundaries.

--- a/book/code-labs/cuahsi-research-notebooks/cuahsi-research-notebooks.md
+++ b/book/code-labs/cuahsi-research-notebooks/cuahsi-research-notebooks.md
@@ -1,21 +1,26 @@
 ---
 title: CUAHSI Research Notebooks
-authors:
-  id: cuahsi
+subtitle: A free, open source gallery of hydrologic and data science Jupyter Notebooks compiled by the CUAHSI community.
 date: 2026-04-22
+github: https://github.com/CUAHSI/notebooks
+authors:
+  - id: cuahsi
+    name: The CUAHSI Community
+    affiliations:
+    - id: cuahsi-affiliation
+      name: CUAHSI - Consortium of Universities for the Advancement of Hydrologic Science, Inc.
+      url: https://cuahsi.org/
+toc: true
 ---
 
 [🏠 Back to Home](/)
 
-<div style="background: linear-gradient(135deg, #e1f5fe 0%, #b3e5fc 100%); padding: 1rem 1.5rem; color: #003366; margin-bottom: 2rem; border-radius: 8px; border: 1px solid #b3e5fc;">
+# Introduction  
 
-<h3 style="margin-top: 0; color: #003366;">Overview</h3>
+**The CUAHSI Research Notebooks gallary a community-curated collection of Jupyter Notebooks that demonstrate practical workflows for hydrologic data access, analysis, and modeling. It showcases reproducible, executable examples that combine code, data, and narrative to support research and education in water science. These notebooks are designed to be used independently, allowing users to learn specific tools or methods without needing to follow a fixed sequence.**  
 
-- **Format:** Jupyter notebooks
-- **Goal:** Applied technical skills and reproducible science
+These notebooks are available in the [Notebooks Repository on the CUAHSI GitHub](https://github.com/CUAHSI/notebooks).
 
-</div>
-
-## Available Resources
+# Available Notebooks
 
 - [Collecting and Manipulating AORC Meteorological Data](<notebooks/Data Access Examples/AORC - Data Collection and Manipulation Primer/collecting-and-manipulating-aorc-v1.1-myst>): A Jupyter notebook showing how to work with the NOAA Analysis of Record for Calibration (AORC) meteorological dataset from the cloud in Python, including subsetting, visualization, and linking gridded data to watershed boundaries.

--- a/book/myst.yml
+++ b/book/myst.yml
@@ -40,7 +40,9 @@ project:
             - file: 'courseware/hydroinformatics/17-calibrate-model-for-loops/17-Calibrate-HBV.md'
     - file: code-labs/code-labs.md
       children:
-        - file: 'code-labs/notebooks/Data Access Examples/AORC - Data Collection and Manipulation Primer/collecting-and-manipulating-aorc-v1.1-myst.ipynb'
+        - file: code-labs/cuahsi-research-notebooks/cuahsi-research-notebooks.md
+          children:
+            - file: 'code-labs/cuahsi-research-notebooks/notebooks/Data Access Examples/AORC - Data Collection and Manipulation Primer/collecting-and-manipulating-aorc-v1.1-myst.ipynb'
     - file: workshops/workshops.md
     - file: standards-and-protocols/standards-and-protocols.md
       # children:


### PR DESCRIPTION
Created a new subdirectory in `code-labs` for the CUAHSI Research Notebooks
- Moved the `/notebooks` submodule
- Updated MyST navigation for cuahsi-research-notebooks
- Created a `cuahsi-research-notebooks/cuahsi-research-notebooks.md` title page
- Fixed sidebar structure for Code Labs
- Updated text within code-labs.md

Closes #71 